### PR TITLE
RFC: base case example for issue #5 (WIP)

### DIFF
--- a/src/spiral/macros.clj
+++ b/src/spiral/macros.clj
@@ -1,0 +1,47 @@
+(ns spiral.macros
+  "Probably makes sense to merge some of this stuff into core, keeping separate
+  while figuring things out"
+  (:require  [clojure.core.async :as async]
+             [clojure.walk :as walk]))
+
+
+
+;; This indiscriminately captures everything in the clojure.core.async namespace and
+;; and rewrites it.
+;; TODO - make a list of ones in core.async that take channel as the last parameter
+;; TODO - walk the tree to find all the relevant core.async functions
+(defn wrap-async-chans [form chan]
+
+  (let [invocation (first form)
+        invocation-namespace (namespace invocation)
+        recursive-fn #(wrap-async-chans % chan)]
+    (cond
+    ;; Following deals sensibly with function calls, since
+    ;; function symbol will not be wrapped
+    (= invocation-namespace "clojure.core.async")  (let [internals (rest form)]
+                                                     `(~invocation ~@internals chan))
+    (seq? form) (map  recursive-fn form )
+    (vector? form ) (map recursive-fn form)
+    (map? form) (map recursive-fn form)
+    (set? form) (map recursive-fn form)
+    :else form)))
+
+
+
+
+(defmacro defhandler [args & body]
+  `(let [req-chan# (async/chan)]
+     (async/go
+       (wrap-async-chans ~@body 'req-chan#)
+      )
+    )
+  )
+
+
+
+
+;;; Test code
+;; (defhandler [req] (async/<! (:test {})))
+;; (defhandler [req] (do (async/<! (:test {}))))
+;; (defhandler [req] (do (loop [i 0] (async/<! (:test {})) (recur (if (< i 2) (inc i))))))
+;; (defhandler [req] (let [chan (async/chan)] ))


### PR DESCRIPTION
Not sure about the nesting approach but this seems to do at least the base case of core.async form, it needs to handle walking the tree, which is doable once the base case is figured out.
